### PR TITLE
Fixed Synnotech.Xunit.props 

### DIFF
--- a/Code/Synnotech.Xunit.Tests/Synnotech.Xunit.Tests.csproj
+++ b/Code/Synnotech.Xunit.Tests/Synnotech.Xunit.Tests.csproj
@@ -11,6 +11,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Light.GuardClauses" Version="10.0.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/Code/Synnotech.Xunit/Synnotech.Xunit.csproj
+++ b/Code/Synnotech.Xunit/Synnotech.Xunit.csproj
@@ -32,7 +32,7 @@ Synntech.Xunit 1.2.1
 
     <ItemGroup>
         <PackageReference Include="xunit.core" Version="2.4.0" />
-        <PackageReference Include="Light.GuardClauses" Version="10.0.0" />
+        <PackageReference Include="Light.GuardClauses" Version="10.0.0" PrivateAssets="all" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />

--- a/Code/Synnotech.Xunit/Synnotech.Xunit.csproj
+++ b/Code/Synnotech.Xunit/Synnotech.Xunit.csproj
@@ -5,7 +5,7 @@
         <Authors>Synnotech AG</Authors>
         <Company>Synnotech AG</Company>
         <Copyright>Copyright © Synnotech AG 2021</Copyright>
-        <Version>1.2.0</Version>
+        <Version>1.2.1</Version>
         <Description>Extensions for xunit test projects.</Description>
         <LangVersion>10.0</LangVersion>
         <Nullable>enable</Nullable>
@@ -22,12 +22,10 @@
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReleaseNotes>
-Synntech.Xunit 1.2.0
+Synntech.Xunit 1.2.1
 --------------------------------
 
-- added possibility to load environment variables
-- instead of using the default configuration, there is now a TestSettings.LoadConfiguration method which can be adjusted
-- introduced Build Server mode that excludes testsettings.Development.json by default
+- replaced Update with Include attributes in Synnotech.Xunit.props
 - you can find the docs at https://github.com/Synnotech-AG/Synnotech.Xunit
         </PackageReleaseNotes>
     </PropertyGroup>

--- a/Code/Synnotech.Xunit/Synnotech.Xunit.props
+++ b/Code/Synnotech.Xunit/Synnotech.Xunit.props
@@ -1,12 +1,12 @@
 <Project>
     <ItemGroup>
-        <None Update="testsettings.Development.json" Condition="Exists('testsettings.Development.json')">
+        <None Include="testsettings.Development.json" Condition="Exists('testsettings.Development.json')">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <None Update="testsettings.Build.json" Condition="Exists('testsettings.Build.json')">
+        <None Include="testsettings.Build.json" Condition="Exists('testsettings.Build.json')">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <None Update="testsettings.json" Condition="Exists('testsettings.json')">
+        <None Include="testsettings.json" Condition="Exists('testsettings.json')">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
     </ItemGroup>

--- a/Code/Synnotech.Xunit/TestSettings.cs
+++ b/Code/Synnotech.Xunit/TestSettings.cs
@@ -9,11 +9,12 @@ namespace Synnotech.Xunit;
 /// Provides an ambient context for test settings. This class loads up to three
 /// optional configuration files ("testsettings.json", "testsettings.Development.json",
 /// and "testsettings.Build.json") as well as environment variables and
-/// provides the <see cref="Configuration" /> property  to access them
+/// provides the <see cref="Configuration" /> property to access them
 /// (if you don't want to use the default settings, you can omit the
 /// <see cref="Configuration" /> property and instead call <see cref="LoadConfiguration" />.
-/// The files are searched for in the current working directory - thus you
-/// should copy the JSON files to the output directory as part of your build.
+/// Synnotech.Xunit will automatically copy testsettings.json, testsettings.Development.json,
+/// and testsettings.Build.json to the output directory if they are present right next
+/// to your csproj file of your test project.
 /// </para>
 /// <para>
 /// All of the sources are optional and can be configured
@@ -81,7 +82,7 @@ public static class TestSettings
 
     /// <summary>
     /// <para>
-    /// Loads an <see cref="IConfiguration" /> object from three files testsettings.json, testsettings.Build.json,
+    /// Loads an <see cref="IConfiguration" /> object from three optional files testsettings.json, testsettings.Build.json,
     /// and testsettings.Development.json, and from environment variables. All of the sources are optional and
     /// can be configured either via the parameters of this method, or by supplying a dedicated section in at least one
     /// of the JSON files:
@@ -131,9 +132,9 @@ public static class TestSettings
     /// </list>
     /// </summary>
     /// <param name="testsettingsFileName">
-    /// The name of the default test settings file ("testsettings.json").
+    /// The name of the default test settings file (testsettings.json).
     /// </param>
-    /// <param name="developmentFileName">The name of the local development file (testsettings.Development.json").</param>
+    /// <param name="developmentFileName">The name of the local development file (testsettings.Development.json).</param>
     /// <param name="buildServerFileName">The name of the build server file (testsettings.Build.json).</param>
     /// <param name="isInBuildServerMode">
     /// The value indicating whether Build Server mode is turned on. If this value is set to null,
@@ -141,12 +142,12 @@ public static class TestSettings
     /// </param>
     /// <param name="isInBuildServerModeEnvironmentVariableName">
     /// The name of the environment variable that indicates whether Build Server mode is active.
-    /// The value of this environment variable must be either "True" or "1" for Build Server mode to
+    /// The value of this environment variable (not the parameter) must be either "True" or "1" for Build Server mode to
     /// be activated.
     /// </param>
     /// <param name="loadEnvironmentVariables">
     /// The value indicating whether the returned <see cref="IConfiguration" /> object will also contain
-    /// values from environment variables. If this value is set null, this method will try to obtain the
+    /// values from environment variables. If this value is set to null, this method will try to obtain the
     /// value from one of the JSON files.
     /// </param>
     /// <param name="environmentVariablesPrefix">


### PR DESCRIPTION
- in Synnotech.Xunit.props, we now use Include instead of Update for all testsettings files
- added missing docs and XML comments for the new TestSettings features
- Light.GuardClauses is now referenced privately